### PR TITLE
Externals fix

### DIFF
--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -12,7 +12,10 @@ const server = {
     output: {
         path: BUILD_PATH,
         filename: 'server.js'
-    }
+    },
+    externals: {
+		canvas: 'commonjs canvas'
+	}
 }
 
 const app = {


### PR DESCRIPTION
Added...

```
externals: {
    canvas: 'commonjs canvas'
}
```

...to `webpack.config.js` as per [this suggestion](https://github.com/jsdom/jsdom/issues/2508).


## Caveat

This fix seems to work, however it requires a change to the project. This does not satisfy the need to avoid the SDK itself breaking the project.